### PR TITLE
accomidated for libogc changes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -118,7 +118,7 @@ MAP    ?= $(BIN)/boot.map
 # Variable init
 
 # The names of libraries to use.
-LIBS     := ogc mxml fat bte wiiuse
+LIBS     := ogc mxml fat bte wiiuse m
 # The source files to compile.
 SRC      :=
 # Phony targets

--- a/src/network.h
+++ b/src/network.h
@@ -40,7 +40,7 @@
 #define  SO_ERROR			0x1007    /* get error status and clear */
 #define  SO_TYPE			0x1008    /* get socket type */
 
-s32 net_ip_top_fd;
+extern s32 net_ip_top_fd;
 
 /*
  * Structure used for manipulating linger option.


### PR DESCRIPTION
very simple edits to the Makefile to link against `m` which is now (seemingly) required by libogc. Also defined `net_ip_top_fd` as an `extern` which seems to be needed with newer versions of `powerpc-eabi-gcc` (thanks @Chadderz121 for pointing this out!)

no idea why, but compiling a new version also fixes issue #14 (according to the creator of the issue)